### PR TITLE
fix(package): files include image directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A collection of all emojis supported on ReadMe.",
   "main": "src/index.js",
   "files": [
-    "unicode"
+    "unicode",
+    "src/img"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "files": [
     "unicode",
-    "src/img"
+    "src"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Installing v2.0.0 of this package in ReadMe fails because it cannot find the folder of images.  I think this may be due to the addition of the files field to the package definition, and indeed it seems to missing from the package in the broken install:

```bash
@readme/emojis
├── src/
│   │   # urmmmm, but where is img/???
│   └── index.js
├── unicode/
├── LICENSE
├── README.md
└── package.json
```

### Changes

- [x] add `src/img` to the package's files field + pray